### PR TITLE
Suggested styling to fix issues I mentioned for this pull request

### DIFF
--- a/htdocs/js/apps/Scaffold/scaffold.css
+++ b/htdocs/js/apps/Scaffold/scaffold.css
@@ -1,6 +1,6 @@
 .section-div > .accordion-heading > a.accordion-toggle {
 	color: #212121;
-	padding: 2px 0;
+	padding: 2px 1.25rem 2px 0;
 	border: 1px solid #AAAAAA;
 	border-top-left-radius: 3.3px;
 	border-top-right-radius: 3.3px;
@@ -71,7 +71,10 @@
 .section-div > .accordion-body div.accordion-inner {
 	background: #FAFAFA;
 	padding: 1rem 1.25rem;
-	padding-right: 0;
 	border-bottom-left-radius: 3.3px;
 	border-bottom-right-radius: 3.3px;
+}
+
+.section-div > .accordion-body .section-div {
+	margin-right: calc(-1.25rem - 1px);
 }


### PR DESCRIPTION
Style tweaks to make nested accordions right aligned, but still maintain padding for the rest of the content.

This also adds the padding back to the right of the collapse icon.