### PR TITLE
Restructure things a bit and add css style to improve the sticky nav appearance

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -93,7 +93,9 @@
 	<!--#endif-->
 	
 	<!--#if can="nav"-->
+	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
 		<!--#nav separator="  "-->
+	</div>
 	<!--#endif-->
 	
 	<!--#if can="title"-->

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -245,6 +245,10 @@ div.unattempted-progress {
 }
 
 /* Main Content */
+body {
+	padding: 0;
+}
+
 .body {
 	display: inline-block;
 	float: left;
@@ -291,20 +295,23 @@ h2.page-title {
 }
 
 /* Question nav section */
-.problem-nav {
-	margin-bottom:1ex;
-	display: inline-block;
-}
-	
-.row-fluid.sticky, .user-nav {
+.sticky-nav {
+	display: flex;
+	flex-wrap: wrap;
 	z-index: 1;
 	position: sticky;
 	top: 0;
 	background-color: white;
+	margin-bottom: 1rem;
+	padding: 0.25rem;
+	border-radius: 4px;
+	box-shadow: 0 0 0.25rem 1px gray;
+	box-sizing: border-box;
 }
 
-.problem-nav .user-nav {
-	margin-bottom: 5px;
+.sticky-nav > a,
+.sticky-nav > div {
+	margin: 0.25rem auto 0.25rem 0.25rem;
 }
 
 .user-nav .student-nav-selector .dropdown-menu {

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -157,21 +157,17 @@
 	</div></div>
 	<!--#endif-->
 
-	<!--#if can="nav" can="message"--> 
-	<div class="row-fluid sticky">
-	  <div id="problem-nav" class="problem-nav span7" role="navigation" aria-label="problem navigation">
-	<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
-	<!--#if can="nav"-->
+	<!--#if can="message"--> 
+	<div id="Message" class="Message row-fluid">
+		<!-- Message for the user -->
+		<!--#message-->
+	</div>
+	<!--#endif-->
+
+	<!--#if can="nav"--> 
+	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
+		<!-- Question Navigation, e.g.: Prev, Up, Next for homeworks -->
 		<!--#nav style="buttons" imageprefix="/webwork2_files/images/nav" imagesuffix=".gif" separator="  "-->
-	<!--#endif-->
-	  </div>
-	  
-	  <div id="Message" class="Message span4 offset1">
-	    <!-- Message for the user -->
-	    <!--#if can="message"-->
-	        <!--#message-->
-	<!--#endif-->
-	  </div>
 	</div>
 	<!--#endif-->
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1208,7 +1208,7 @@ sub nav {
 		if defined $self->{will}->{showOldAnswers};
 	$tail .= "&showProblemGrader=" . $self->{will}{showProblemGrader}
 		if defined $self->{will}{showProblemGrader};
-	return $userNav . $self->navMacro($args, $tail, @links);
+	return $userNav . CGI::div($self->navMacro($args, $tail, @links));
 }
 
 sub path {


### PR DESCRIPTION
This is an idea to make the sticky nav better.  I realized that the main thing that I didn't like about just adding sticky to the row-fluid div is that it gives it a disembodied look.  Restructuring, adding a box shadow, and a few other css style tweaks improves things quite a bit for me.  What do you think of this?

The message div is moved out above the user/problem nav in the main template. The nav div is added to the gateway template.

This div that is now in both templates is styled with a box shadow to set it off from the rest of the page.  This gives it a nav header
appearance that works well when sticky takes effect.

The padding that bootstrap 2.3.2 adds to the body on narrow screens is overriden. This is something that version 2.3.2 of bootstrap does wrong.  Eating up the width with padding on an already narrow screen is just not well though out.  Newer versions of bootstrap don't do this.  This makes it so that the nav buttons don't wrap as often.  Long student names will still make the student nav wrap though.