### PR TITLE
More suggestions for improvement

### DIFF
--- a/htdocs/themes/math4/gateway.template
+++ b/htdocs/themes/math4/gateway.template
@@ -93,13 +93,11 @@
 	<!--#endif-->
 	
 	<!--#if can="nav"-->
-	<div class="problem-nav row-fluid sticky-nav" role="navigation" aria-label="problem navigation">
-		<!--#nav separator="  "-->
-	</div>
+	<!--#nav separator="  "-->
 	<!--#endif-->
 	
 	<!--#if can="title"-->
-	<h1 id="content"><!--#title--></h1>
+	<h1><!--#title--></h1>
 	<!--#endif-->
 	
 	<!--#if can="message"-->

--- a/htdocs/themes/math4/math4.css
+++ b/htdocs/themes/math4/math4.css
@@ -857,7 +857,8 @@ table.attemptResults span.answer-preview {
 /*styles for the instructor comment box */
 
 .answerComments {
-    margin-left: 2em;
+    margin-left: auto;
+    margin-right: auto;
     max-width: 80%;
     border-style: outset;
     border-width: 1px;

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -14,13 +14,13 @@ if ($.fn.button.noConflict) $.fn.bootstrapBtn = $.fn.button.noConflict();
 	var hideSidebar = function () {
 		$('#site-navigation').remove();
 		$('#toggle-sidebar-icon i').removeClass('fa-chevron-left').addClass('fa-chevron-right');
-		$('#content').removeClass('span10').addClass('span11');
+		$('#content').removeClass('span10').addClass('span12').css('margin-left', '0');
 	};
 
 	var showSidebar = function () {
 		$('#body-row').prepend(navigation_element);
 		$('#toggle-sidebar-icon i').addClass('fa-chevron-left').removeClass('fa-chevron-right');
-		$('#content').addClass('span10').removeClass('span11');	
+		$('#content').addClass('span10').removeClass('span12').css('margin-left', '');
 	};
 
 	var toggleSidebar = function () {
@@ -34,7 +34,7 @@ if ($.fn.button.noConflict) $.fn.bootstrapBtn = $.fn.button.noConflict();
 	// if no fish eye then collapse site-navigation 
 	if($('#site-links').length > 0 && !$('#site-links').html().match(/[^\s]/)) {
 		$('#site-navigation').remove();
-		$('#content').removeClass('span10').addClass('span11');
+		$('#content').removeClass('span10').addClass('span12').css('margin-left', '0');
 		$('#toggle-sidebar').addClass('hidden');
 		$('#breadcrumb-navigation').width('100%');
 	} else {

--- a/htdocs/themes/math4/system.template
+++ b/htdocs/themes/math4/system.template
@@ -195,37 +195,37 @@
 		  <div id="problem_body" class="Body span12">
 
 			<!--#if can="output_custom_edit_message"-->
-			<div id="custom_edit_message" class="row-fluid"><div class="span10">
+			<div id="custom_edit_message" class="row-fluid"><div class="span12">
 				<!--#output_custom_edit_message-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 			<!--#if can="output_summary"-->
-			<div class="row-fluid"><div id="output_summary" class="span10">
+			<div class="row-fluid"><div id="output_summary" class="span12">
 					<!--#output_summary-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 
 			<!--#if can="output_achievement_message"-->
-			<div class="row-fluid"><div id="output_achievement_message" class="span10">
+			<div class="row-fluid"><div id="output_achievement_message" class="span12">
 					<!--#output_achievement_message-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 			
 			<!--#if can="output_comments" "-->
-			<div class="row-fluid"><div id="output_comments" class="span10">
+			<div class="row-fluid"><div id="output_comments" class="span12">
 				  <!--#output_comments-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 
 			<!--#if can="output_grader"-->
-			<div class="row-fluid"><div id="output_grader" class="span10">
+			<div class="row-fluid"><div id="output_grader" class="span12">
 				<!--#output_grader-->
-			</div><div class="span2"></div></div>
+			</div></div>
 			<!--#endif-->
 
 			<!--#if can="output_form_start"-->
 			<div class="row-fluid">
-			  <div class="span10">
+			  <div class="span12">
 				<!--#output_form_start-->
 			    <!--#if can="output_hidden_info"-->
 				     <!--#output_hidden_info-->
@@ -279,7 +279,7 @@
 			</div>
 		<!--#endif-->
 
-		</div><div class="span2"></div></div>
+		</div></div>
                 </div></div>
 
 	<!-- ====  end printing body parts   -->

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1214,6 +1214,7 @@ sub nav {
 
 		# Set up the student nav.
 		print join("",
+			CGI::start_div({ class => "row-fluid sticky-nav", role => "navigation", aria_label => "user navigation"}),
 			CGI::start_div({ class => 'user-nav' }),
 			$prevTest
 			? CGI::a({
@@ -1257,6 +1258,7 @@ sub nav {
 					class => "nav_button student-nav-button"
 				}, $r->maketext("Next Test"))
 			: CGI::span({ class => "gray_button" }, $r->maketext("Next Test")),
+			CGI::end_div(),
 			CGI::end_div()
 		);
 	}


### PR DESCRIPTION
The first commit allows the content div in the system template take up as much width as it can instead of leaving empty space on the right.  To me this just looks better.

The second commit is to address an issue if the user nav is not present in gateway quizzes.  In that case the presence of the sticky-nav div with its css styling looks bad.  There is a thin empty bar floating at the top of the screen.  The only way I could think of to fix this is to move that div into the nav method of the GatewayQuiz.pm module, and out of the template.  So nothing is actually there if the user nav is not output.