### PR TITLE
Set the content type header in the correct place.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -186,6 +186,9 @@ sub formatRenderedProblem {
 		}
 		$dom->wrap_content('<answerhashes></answerhashes>');
 		$answerhashXML = $dom->to_string;
+
+		$ws->c->res->headers->content_type('text/xml; charset=utf-8')
+			if $ws->c->current_route eq 'render_rpc' && ($ws->c->param('displayMode') // '') eq 'PTX';
 	}
 
 	# Make sure this is defined and is an array reference as saveGradeToLTI might add to it.

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -122,18 +122,6 @@ sub startup ($app) {
 		);
 	}
 
-	# Always add Content-Type: text/xml; charset=utf-8 header for static PTX
-	$app->hook(
-		before_dispatch => sub ($c) {
-			if ($c->req->url->path =~ /^\/webwork2\/render_rpc/
-				&& $c->req->url->query->param('outputformat') eq 'ptx'
-				&& $c->req->url->query->param('displayMode') eq 'PTX')
-			{
-				$c->res->headers->header('Content-Type' => 'text/xml; charset=utf-8');
-			}
-		}
-	);
-
 	# Add a hook that redirects http to https if configured to do so.
 	if ($config->{redirect_http_to_https}) {
 		$app->hook(


### PR DESCRIPTION
This only sets the "text/xml" header if the route is the "render_rpc" route and the output format is "ptx" and the display mode is "PTX". This is done in `FormatRenderedProblem` (instead of `RenderViaRPX` as I suggested earlier) because it needs to be done before the response is rendered, and that occurs at the end of the `formatRenderedProblem` method.