### PR TITLE
Fix some issues that have cropped up if a user attempts to access the editor without sufficient permissions.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -232,7 +232,7 @@ sub initialize ($c) {
 	$c->stash->{hardcopyLabels}   = [];
 
 	# Tell the templates if we are working on a PG file
-	$c->{is_pg} = ($c->{file_type} eq 'course_info') ? 0 : 1;
+	$c->{is_pg} = $c->{file_type} && $c->{file_type} eq 'course_info' ? 0 : 1;
 
 	# Check permissions
 	return
@@ -336,17 +336,20 @@ sub path ($c, $args) {
 	# page.  The bread crumb path leads back to the problem being edited, not to the Instructor tool.
 	return $c->pathMacro(
 		$args,
-		'WeBWorK'                  => $c->url_for('root'),
-		$c->stash('courseID')      => $c->url_for('set_list'),
-		($c->stash('setID') // '') => $c->url_for('problem_list'),
-		$c->{prettyProblemNumber}  => $c->url_for('problem_detail', problemID => $c->stash('problemID') || ''),
-		$c->maketext('Editor')     => ''
+		'WeBWorK'                         => $c->url_for('root'),
+		$c->stash('courseID')             => $c->url_for('set_list'),
+		($c->stash('setID') // '')        => $c->url_for('problem_list'),
+		($c->{prettyProblemNumber} // '') =>
+			$c->url_for('problem_detail', problemID => $c->stash('problemID') || ''),
+		$c->maketext('Editor') => ''
 	);
 }
 
 sub page_title ($c) {
 	my $setID     = $c->stash('setID');
 	my $problemID = $c->stash('problemID');
+
+	return 'Editor' unless $c->{file_type};
 
 	return $c->maketext('Set Header for set [_1]',            $setID) if $c->{file_type} eq 'set_header';
 	return $c->maketext('Hardcopy Header for set [_1]',       $setID) if $c->{file_type} eq 'hardcopy_header';

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -2,7 +2,7 @@
 % use WeBWorK::HTML::CodeMirrorEditor
 	% qw(generate_codemirror_html generate_codemirror_controls_html output_codemirror_static_files);
 %
-% my $codemirrorMode = $c->{file_type} eq 'course_info' ? 'htmlmixed' : 'PG';
+% my $codemirrorMode = $c->{file_type} && $c->{file_type} eq 'course_info' ? 'htmlmixed' : 'PG';
 % content_for js => begin
 	<%= output_codemirror_static_files($c, $codemirrorMode) =%>
 	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'),           defer => undef =%>


### PR DESCRIPTION
There are several warning that are now occurring if a user without the `access_instructor_tools` and `modify_student_data` permissions attempts to access the PG problem editor.  A user can do this by entering the url `http://server_root_url/webwork2/course_id/instructor/pgProblemEditor`.  This should not emit any warnings, and the page should simply display "You are not authorizes to access instructor tools" or "You are not authorized to modify problems" (depending on which of the permissions is lacking).  Currently there are several warnings emitted about things not being defined.

These warnings are caused by changes that myself, @somiaj, and @Alex-Jordan have recently made to the code.