### PR TITLE
Implement suggestions made in my review of openwebwork/webwork2#2266

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -16,8 +16,6 @@
 package WeBWorK::ContentGenerator::Instructor::ProblemSetDetail;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
-use Exporter qw(import);
-
 =head1 NAME
 
 WeBWorK::ContentGenerator::Instructor::ProblemSetDetail - Edit general set and
@@ -25,10 +23,12 @@ specific user/set information as well as problem information
 
 =cut
 
+use Exporter qw(import);
+
 use WeBWorK::Utils qw(cryptPassword jitar_id_to_seq seq_to_jitar_id x format_set_name_internal format_set_name_display);
 use WeBWorK::Utils::Instructor qw(assignProblemToAllSetUsers addProblemToSet);
 
-our @EXPORT_OK = ('FIELD_PROPERTIES');
+our @EXPORT_OK = qw(FIELD_PROPERTIES);
 
 # These constants determine which fields belong to what type of record.
 use constant SET_FIELDS => [

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -75,6 +75,7 @@ sub scrollingRecordList ($options, @records) {
 		}
 
 		$formattedRecords = formatRecords(
+			$c,
 			$c->param("$name!format") || $options{default_format},
 			sortRecords(
 				$c->param("$name!sort") || $options{default_sort} || (@$sorts ? $sorts->[0][1] : ''),

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -51,7 +51,7 @@ use warnings;
 use Carp;
 
 use WeBWorK::Utils qw(sortByName);
-use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw/FIELD_PROPERTIES/;
+use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw(FIELD_PROPERTIES);
 
 our @EXPORT_OK = qw(
 	getFiltersForClass
@@ -118,7 +118,7 @@ sub getFiltersForClass {
 
 		if (keys %visibles > 1) {
 			for my $vis (sortByName(undef, keys %visibles)) {
-				push @filters, [ ($vis ? 'Visible' : "Not Visible") => "visible:$vis" ];
+				push @filters, [ ($vis ? 'Visible' : 'Not Visible') => "visible:$vis" ];
 			}
 		}
 	}

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -16,13 +16,13 @@
 			. 'or select a tool from the list to the left.'
 	) =%>
 	<br>
-	<%= maketext('Select user(s) and/or sets(s) below and click the action button of your choice.') =%>
+	<%= maketext('Select user(s) and/or set(s) below and click the action button of your choice.') =%>
 </p>
 %
 <%= form_for current_route, method => 'POST', id => 'instructor-tools-form', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	%
-	<div class="row gx-3">
+	<div class="row">
 		<div class="col-xl-5 col-md-6 mb-2">
 			<div class="fw-bold text-center"><%= label_for selected_users => maketext('Users') %></div>
 			<%= scrollingRecordList(
@@ -59,200 +59,168 @@
 			) =%>
 		</div>
 	</div>
-	<div class="row gx-3">
-		<div class="col-xl-3 col-md-6">
-			<hr class="divider pb-1 bg-dark my-2">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'sets_assigned_to_user',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Assignments and Dates') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> user') =%>\
-				</span>
+	<div class="row">
+		% # TODO: When bootstrap is upgraded to 5.3 switch the "column-gap" style to the "column-gap-3" class.
+		<div class="col-xl-10 col-md-12 d-flex justify-content-around flex-wrap" style="column-gap:1rem">
+			<div style="min-width:350px">
+				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'sets_assigned_to_user',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name       => 'edit_users',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_user_list'),
+						data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('account data for <b>all selected</b> users') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'user_options',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('account settings for <strong>one</strong> user') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name  => 'user_progress',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('progress for <strong>one</strong> user') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary w-25' =%>
+					<%= number_field number_of_students => 1, min => 1, max => 100,
+						class => 'form-control form-control-sm text-center' =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('new user accounts') =%>\
+					</span>
+				</div>
 			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name       => 'edit_users',
-					class      => 'btn btn-sm btn-secondary col-3',
-					formaction => $c->systemLink(url_for 'instructor_user_list'),
-					data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Account Data') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <b>all selected</b> users') =%>\
-				</span>
+			<div style="min-width:350px">
+				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Assign'),
+						# This name is the same as the name of the submit button in Assigner.pm and the form is
+						# directly submitted to that module without modification.
+						name       => 'assign',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_set_assigner'),
+						data => {
+							users_needed => 'at least one',
+							error_users  => maketext($E_MIN_ONE_USER),
+							sets_needed  => 'at least one',
+							error_sets   => maketext($E_MIN_ONE_SET)
+						} =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('<strong>all selected</strong> users to <strong>all selected</strong> sets') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Act'),
+						name  => 'act_as_user',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => {
+							users_needed => 'exactly one',
+							error_users  => maketext($E_ONE_USER),
+							sets_needed  => 'at most one',
+							error_sets   => maketext($E_MAX_ONE_SET)
+						} =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('as <strong>one</strong> user on <strong>up to one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'edit_set_for_users',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => {
+							sets_needed  => 'exactly one',
+							error_sets   => maketext($E_ONE_SET)
+						} =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users}) =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Score'),
+						name       => 'score_sets',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_scoring'),
+						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('<strong>all selected</strong> sets for <strong>all</strong> users') =%>\
+					</span>
+				</div>
 			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'user_options',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Account Settings') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> user') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View'),
-					name  => 'user_progress',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Progress') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> user') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary col-3' =%>
-				%= number_field number_of_students => 1, min => 1, max => 100, class => 'col-2 flex-grow-1 text-center'
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('new user accounts') =%>\
-				</span>
-			</div>
-		</div>
-		<div class="col-xl-4 col-md-6">
-			<hr class="divider pb-1 bg-dark my-2">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Assign'),
-					# This name is the same as the name of the submit button in Assigner.pm and the form is
-					# directly submitted to that module without modification.
-					name       => 'assign',
-					class      => 'btn btn-sm btn-secondary col-2',
-					formaction => $c->systemLink(url_for 'instructor_set_assigner'),
-					data => {
-						users_needed => 'at least one',
-						error_users  => maketext($E_MIN_ONE_USER),
-						sets_needed  => 'at least one',
-						error_sets   => maketext($E_MIN_ONE_SET)
-					} =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('<strong>all selected</strong> users') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('to <strong>all selected</strong> sets') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Act'),
-					name  => 'act_as_user',
-					class => 'btn btn-sm btn-secondary col-2',
-					data  => {
-						users_needed => 'exactly one',
-						error_users  => maketext($E_ONE_USER),
-						sets_needed  => 'at most one',
-						error_sets   => maketext($E_MAX_ONE_SET)
-					} =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('as <strong>one</strong> user') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('on <strong>up to one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'edit_set_for_users',
-					class => 'btn btn-sm btn-secondary col-2',
-					data  => {
-						sets_needed  => 'exactly one',
-						error_sets   => maketext($E_ONE_SET)
-					} =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Set Detail for <strong>one</strong> set') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>zero or more</strong> users') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Score'),
-					name       => 'score_sets',
-					class      => 'btn btn-sm btn-secondary col-2',
-					formaction => $c->systemLink(url_for 'instructor_scoring'),
-					data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('<strong>all selected</strong> sets') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext(' for <strong>all</strong> users') =%>\
-				</span>
-			</div>
-		</div>
-		<div class="col-xl-3 col-md-6 font-sm">
-			<hr class="divider pb-1 bg-dark my-2">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'users_assigned_to_set',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Assigned Users') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Add'),
-					name  => 'prob_lib',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Library Browser Exercises') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('to <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View'),
-					name  => 'set_stats',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Statistics') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View'),
-					name  => 'set_progress',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Progress') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Create'),
-					name  => 'create_set',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => {
-						set_name_needed        => 'true',
-						error_set_name         => maketext($E_SET_NAME),
-						error_invalid_set_name => maketext($E_BAD_NAME)
-					} =%>
-				<%= label_for new_set_name => maketext('New Set:'), class => 'input-group-text' =%>
-				<%= text_field new_set_name => '',
-					id          => 'new_set_name',
-					placeholder => maketext('Name for new set here'),
-					size        => 20,
-					class       => 'form-control form-control-sm',
-					dir         => 'ltr' =%>
+			<div style="min-width:350px">
+				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'users_assigned_to_set',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('assigned users for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Add'),
+						name  => 'prob_lib',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('problems to <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name  => 'set_stats',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('statistics for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name  => 'set_progress',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('progress for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Create'),
+						name  => 'create_set',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => {
+							set_name_needed        => 'true',
+							error_set_name         => maketext($E_SET_NAME),
+							error_invalid_set_name => maketext($E_BAD_NAME)
+						} =%>
+					<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
+					<%= text_field new_set_name => '',
+						id          => 'new_set_name',
+						placeholder => maketext('New set name'),
+						size        => 20,
+						class       => 'form-control form-control-sm',
+						dir         => 'ltr' =%>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -126,13 +126,12 @@
 					<div class="mb-2">
 						<%= scrollingRecordList(
 							{
-								name                => 'classList',
-								controller          => $c,
-								default_sort        => 'lnfn',
-								default_format      => 'lnfn_uid',
-								default_filters     => ['all'],
-								refresh_button_name => maketext('Change Display Settings'),
-								attrs               => { size => 5, multiple => undef }
+								name            => 'classList',
+								controller      => $c,
+								default_sort    => 'lnfn',
+								default_format  => 'lnfn_uid',
+								default_filters => ['all'],
+								attrs           => { size => 5, multiple => undef }
 							},
 							@{ $c->{ra_user_records} }
 						) =%>

--- a/templates/HelpFiles/Hardcopy.html.ep
+++ b/templates/HelpFiles/Hardcopy.html.ep
@@ -23,7 +23,7 @@
 </p>
 <p>
 	<%= maketext('In both cases, one can select the sort field, the format of the display list, and the filter. '
-		. '"Change Display Settings" must be clicked to update the list.') =%>
+		. '"Refresh List" must be clicked to update the list.') =%>
 </p>
 <p>
 	<%= maketext('There are many options available at the bottom:') =%>

--- a/templates/HelpFiles/InstructorAssigner.html.ep
+++ b/templates/HelpFiles/InstructorAssigner.html.ep
@@ -21,7 +21,7 @@
 		. 'unassign the given sets. The list of users or the list of sets can be reordered under the "sort" '
 		. 'option or the format of the user or set list.  Additionally, the set lists can be filtered '
 		. '(by section number or recitation).  The displayed user and set lists will only be updated '
-		. 'upon clicking "Change Display Settings".') =%>
+		. 'upon clicking "Refresh List".') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Multiple users or sets may be selected by holding down the shift key or the ctrl key while '

--- a/templates/HelpFiles/InstructorIndex.html.ep
+++ b/templates/HelpFiles/InstructorIndex.html.ep
@@ -21,14 +21,14 @@
 		. 'common actions that allow selecting multiple users or sets to act on at once.  Because multiple users '
 		. 'and sets can be acted on at the same time, it is often more efficient to use this page when modifying '
 		. 'multiple items.  For example, after selecting several users and a set you can change the close date for '
-		. 'all selected users for that set.  This page also gives access to "Edit Assignments and Dates for one user", '
+		. 'all selected users for that set.  This page also gives access to "Edit assignments and dates for one user", '
 		. 'which can be used to access settings for all sets including test versions for that user.') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Use the "Users" and "Sets" forms to select which users and sets to act on.  Multiple items can be '
 		. 'selected using ctrl-click or shift-click.  The action buttons are grouped into three categories.  The '
-		. 'first is a set of actions that act on the selected users, the last is a set of actions that act on the '
-		. 'selected sets, and the middle is a set of actions for acting on a combination of sets and users.  If an '
+		. 'first is a set of actions that act on the selected users, the second is a set of actions for acting on a '
+		. 'combination of sets and users, and the third is a set of actions that act on the selected sets.  If an '
 		. 'invalid number of users or sets are selected, the action will not be preformed, and an error message '
 		. 'will be placed on the page.') =%>
 </p>

--- a/templates/HelpFiles/InstructorSendMail.html.ep
+++ b/templates/HelpFiles/InstructorSendMail.html.ep
@@ -19,7 +19,7 @@
 <p>
 	<%= maketext('Use this page to send emails to active (enrolled or auditing) students.  Emails can be sent to '
 		. 'all active students or selected students.  Use the "Students" form to sort, filter, or format how '
-		. 'the user name is displayed.  Click "Change Display Settings" to apply any changes.  Use control-click '
+		. 'the user name is displayed.  Click "Refresh List" to apply any changes.  Use control-click '
 		. 'or shift-click to select multiple students to email.') =%>
 </p>
 <p>


### PR DESCRIPTION
This uses `flex` rules to make the category input groups behave better. The categories are wrapped in a div with fixed width.  The width is chosen to be as small as possible such that the input groups do not wrap.  Thus this dispenses with trying to make the category widths match the scrolling record list which really wasn't working.  `flex-wrap` is used with "around" justification.  So at extra large window widths all three categories will be in the same row.  However, when the categories don't fit, they wrap.  The justification gives nicer positioning in any case.

I merged the input texts, removed capitalization, and changed some of the wording in a few cases.  For example, I don't think that the "Library Browser Exercises" is good.  I think the reference to the library browser is unnecessary, and using "exercises" instead of "problems" is inconsistent the wording used everywhere else in webwork2.

The other changes made are more explicit in the comments made in my review.