### PR TITLE
Style tweaks for the new tabbed layout of the instructor tools input groups.

### DIFF
--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -37,7 +37,7 @@
 				@$users
 			) =%>
 		</div>
-		<div class="col-xl-5 col-md-6 mb-2">
+		<div class="col-xl-5 col-md-6 mb-3">
 			<div class="fw-bold text-center"><%= label_for selected_sets => maketext('Sets') %></div>
 			<%= scrollingRecordList(
 				{
@@ -56,235 +56,240 @@
 			) =%>
 		</div>
 	</div>
+	%
+	<div class="row">
+		<div id="instructor-tools-nav" class="col-xl-10 col-md-12">
+			<ul class="nav nav-pills nav-justified mb-3" id="pills-tab" role="tablist">
+				<li class="nav-item mx-1" role="presentation">
+					<button
+						class="nav-link active border rounded-pill"
+						id="pills-user-actions-tab"
+						data-bs-toggle="pill"
+						data-bs-target="#user-actions"
+						type="button"
+						role="tab"
+						aria-controls="pills-user-actions"
+						aria-selected="true">\
+						<%== maketext('User Actions') =%>\
+					</button>
+				</li>
+				<li class="nav-item mx-1" role="presentation">
+					<button
+						class="nav-link border rounded-pill"
+						id="pills-user-set-actions-tab"
+						data-bs-toggle="pill"
+						data-bs-target="#user-set-actions"
+						type="button"
+						role="tab"
+						aria-controls="pills-user-set-actions"
+						aria-selected="false">\
+						<%== maketext('User-Set Actions') =%>\
+					</button>
+				</li>
+				<li class="nav-item mx-1" role="presentation">
+					<button
+						class="nav-link border rounded-pill"
+						id="pills-set-actions-tab"
+						data-bs-toggle="pill"
+						data-bs-target="#set-actions"
+						type="button"
+						role="tab"
+						aria-controls="pills-set-actions"
+						aria-selected="false">\
+						<%== maketext('Set Actions') =%>\
+					</button>
+				</li>
+			</ul>
 
-	<div id="instructor-tools-nav" class="col-10">
-		<ul class="nav nav-pills nav-justified mb-3" id="pills-tab" role="tablist">
-			<li class="nav-item" role="presentation">
-				<button
-					class="nav-link active border rounded-pill"
-					id="pills-user-actions-tab"
-					data-bs-toggle="pill"
-					data-bs-target="#user-actions"
-					type="button"
-					role="tab"
-					aria-controls="pills-user-actions"
-					aria-selected="true">\
-					<%== maketext('User Actions') =%>\
-				</button>
-			</li>
-			<li class="nav-item" role="presentation">
-				<button
-					class="nav-link border rounded-pill"
-					id="pills-user-set-actions-tab"
-					data-bs-toggle="pill"
-					data-bs-target="#user-set-actions"
-					type="button"
-					role="tab"
-					aria-controls="pills-user-set-actions"
-					aria-selected="false">\
-					<%== maketext('User-Set Actions') =%>\
-				</button>
-			</li>
-			<li class="nav-item" role="presentation">
-				<button
-					class="nav-link border rounded-pill"
-					id="pills-set-actions-tab"
-					data-bs-toggle="pill"
-					data-bs-target="#set-actions"
-					type="button"
-					role="tab"
-					aria-controls="pills-set-actions"
-					aria-selected="false">\
-					<%== maketext('Set Actions') =%>\
-				</button>
-			</li>
-		</ul>
-
-		<div class="tab-content row" id="pills-tabContent">
-			<div id="user-actions" class="tab-pane fade show active col-6" role="tabpanel"
-				aria-labelledby="pills-user-actions-tab" >
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'sets_assigned_to_user',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
-					</span>
+			<div class="tab-content row" id="pills-tabContent">
+				<div class="tab-pane fade show active col-lg-6 col-sm-8" id="user-actions" role="tabpanel"
+					aria-labelledby="pills-user-actions-tab">
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'sets_assigned_to_user',
+							class => 'btn btn-sm btn-secondary',
+							data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name       => 'edit_users',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_user_list'),
+							data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('account data for <b>selected</b> users') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'user_options',
+							class => 'btn btn-sm btn-secondary',
+							data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('account settings for <strong>one</strong> user') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name  => 'user_progress',
+							class => 'btn btn-sm btn-secondary',
+							data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('progress for <strong>one</strong> user') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Email'),
+							name  => 'email_users',
+							class => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_mail_merge') =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('<strong>selected</strong> users') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Add'), name => 'add_users',
+							class => 'btn btn-sm btn-secondary' =%>
+						<%= number_field number_of_students => 1, min => 1, max => 100,
+							class => 'form-control form-control-sm text-center' =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('new user accounts') =%>\
+						</span>
+					</div>
 				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name       => 'edit_users',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_user_list'),
-						data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('account data for <b>selected</b> users') =%>\
-					</span>
+				<div class="tab-pane fade show offset-xxl-3 offset-lg-2 offset-sm-1 col-xxl-6 col-lg-8 col-sm-10"
+					id="user-set-actions" role="tabpanel" aria-labelledby="pills-user-set-actions-tab">
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Assign'),
+							# This name is the same as the name of the submit button in Assigner.pm and the form is
+							# directly submitted to that module without modification.
+							name       => 'assign',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_set_assigner'),
+							data => {
+								users_needed => 'at least one',
+								error_users  => maketext($E_MIN_ONE_USER),
+								sets_needed  => 'at least one',
+								error_sets   => maketext($E_MIN_ONE_SET)
+							} =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('<strong>selected</strong> users to <strong>selected</strong> sets') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Act'),
+							name  => 'act_as_user',
+							class => 'btn btn-sm btn-secondary',
+							data  => {
+								users_needed => 'exactly one',
+								error_users  => maketext($E_ONE_USER),
+								sets_needed  => 'at most one',
+								error_sets   => maketext($E_MAX_ONE_SET)
+							} =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext('as <strong>one</strong> user on <strong>up to one</strong> set')
+						=%></span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'edit_set_for_users',
+							class => 'btn btn-sm btn-secondary',
+							data  => {
+								sets_needed  => 'exactly one',
+								error_sets   => maketext($E_ONE_SET)
+							} =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users})
+						=%></span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name       => 'show_answers',
+							class      => 'btn btn-sm btn-secondary' =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext('answer log for <strong>selected</strong> users, '
+								. 'for <strong>selected</strong> sets')
+						=%></span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Generate'),
+							name       => 'hardcopy',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'hardcopy') =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext('PDF hardcopy for <strong>selected</strong> users, '
+								. 'for <strong>selected</strong> sets')
+						=%></span>
+					</div>
 				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'user_options',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('account settings for <strong>one</strong> user') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name  => 'user_progress',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('progress for <strong>one</strong> user') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Email'),
-						name  => 'email_users',
-						class => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_mail_merge') =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('<strong>selected</strong> users') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary col-2' =%>
-					<%= number_field number_of_students => 1, min => 1, max => 100,
-						class => 'form-control form-control-sm text-center' =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('new user accounts') =%>\
-					</span>
-				</div>
-			</div>
-			<div class="tab-pane fade show offset-md-3 col-6" id="user-set-actions" role="tabpanel"
-				aria-labelledby="pills-user-set-actions-tab" >
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Assign'),
-						# This name is the same as the name of the submit button in Assigner.pm and the form is
-						# directly submitted to that module without modification.
-						name       => 'assign',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_set_assigner'),
-						data => {
-							users_needed => 'at least one',
-							error_users  => maketext($E_MIN_ONE_USER),
-							sets_needed  => 'at least one',
-							error_sets   => maketext($E_MIN_ONE_SET)
-						} =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('<strong>selected</strong> users to <strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Act'),
-						name  => 'act_as_user',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => {
-							users_needed => 'exactly one',
-							error_users  => maketext($E_ONE_USER),
-							sets_needed  => 'at most one',
-							error_sets   => maketext($E_MAX_ONE_SET)
-						} =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('as <strong>one</strong> user on <strong>up to one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'edit_set_for_users',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => {
-							sets_needed  => 'exactly one',
-							error_sets   => maketext($E_ONE_SET)
-						} =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users}) =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name       => 'show_answers',
-						class      => 'btn btn-sm btn-secondary col-2' =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('answer log for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Generate'),
-						name       => 'hardcopy',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'hardcopy') =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('PDF hardcopy for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-			</div>
-			<div class="tab-pane fade show row offset-md-6 col-6" id="set-actions" role="tabpanel"
-				aria-labelledby="pills-set-actions-tab" >
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'users_assigned_to_set',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('assigned users for <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Add'),
-						name  => 'prob_lib',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('problems to <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name  => 'set_stats',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('statistics for <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name  => 'set_progress',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('progress for <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Score'),
-						name       => 'score_sets',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_scoring'),
-						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('<strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Create'),
-						name  => 'create_set',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => {
-							set_name_needed        => 'true',
-							error_set_name         => maketext($E_SET_NAME),
-							error_invalid_set_name => maketext($E_BAD_NAME)
-						} =%>
-					<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
-					<%= text_field new_set_name => '',
-						id          => 'new_set_name',
-						placeholder => maketext('New set name'),
-						size        => 20,
-						class       => 'form-control form-control-sm',
-						dir         => 'ltr' =%>
+				<div class="tab-pane fade show row offset-lg-6 offset-sm-4 col-lg-6 col-sm-8"
+					id="set-actions" role="tabpanel" aria-labelledby="pills-set-actions-tab">
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'users_assigned_to_set',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('assigned users for <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Add'),
+							name  => 'prob_lib',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('problems to <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name  => 'set_stats',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('statistics for <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name  => 'set_progress',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('progress for <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Score'),
+							name       => 'score_sets',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_scoring'),
+							data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('<strong>selected</strong> sets') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Create'),
+							name  => 'create_set',
+							class => 'btn btn-sm btn-secondary',
+							data  => {
+								set_name_needed        => 'true',
+								error_set_name         => maketext($E_SET_NAME),
+								error_invalid_set_name => maketext($E_BAD_NAME)
+							} =%>
+						<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
+						<%= text_field new_set_name => '',
+							id          => 'new_set_name',
+							placeholder => maketext('New set name'),
+							size        => 20,
+							class       => 'form-control form-control-sm',
+							dir         => 'ltr' =%>
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
At different window widths there is now a lot of wrapping of the input groups since we have switched back to using the bootstrap grid layout. Particularly with the latest wording changes that make some of the input group texts even longer.  So this adjusts the `col` sizes at narrower window widths to prevent that, and allow ample room for translations that might be longer.

Make the pill buttons match the width of the scrolling record list above at all layouts, and add a small margin to give them some separation.

Add a missing `row` div to contain the `instructor-tools-nav`.  In bootstrap's grid layout a `col` must be a direct descendent of a `row` div.  (Hide whitespace changes to minimize the differences shown caused by this.)

Remove the `col-2` on the submit buttons.  Those are not direct descendents of a `row` div, and so should not have that class. Furthermore, the `min-width` set in math4.scss overrides that anyway.

Make the margin below the scrolling record list match the margin after the pill buttons for even spacing.

Fix some overly long lines.