### PR TITLE
Make the footer width adjustable per page.

### DIFF
--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -172,7 +172,7 @@
 		% }
 		%
 		% # Footer
-		<div id="footer" role="contentinfo" class="row"><%= include 'ContentGenerator/Base/footer' %></div>
+		<%= include 'ContentGenerator/Base/footer' =%>
 	</div>
 </div>
 %

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -122,6 +122,8 @@ async sub go ($c) {
 
 	my $tx = $c->render_later->tx;
 
+	$c->stash->{footerWidthClass} = 'col-12';
+
 	if ($c->can('pre_header_initialize')) {
 		my $pre_header_initialize = $c->pre_header_initialize;
 		await $pre_header_initialize

--- a/templates/ContentGenerator/Base/footer.html.ep
+++ b/templates/ContentGenerator/Base/footer.html.ep
@@ -1,13 +1,15 @@
-<div class="col-lg-10">
-	<div id="last-modified"><%= maketext('Page generated at [_1]', $c->timestamp) %></div>
-	<div id="copyright">
-		<%== maketext(
-			'WeBWorK &copy; [_1] | theme: [_2] | ww_version: [_3] | pg_version [_4]',
-			$ce->{WW_COPYRIGHT_YEARS} || '1996-2023',
-			$ce->{defaultTheme}       || 'unknown -- set defaultTheme in localOverides.conf',
-			$ce->{WW_VERSION}         || 'unknown -- set WW_VERSION in VERSION',
-			$ce->{PG_VERSION}         || 'unknown -- set PG_VERSION in ../pg/VERSION'
-		) %>
+<div id="footer" role="contentinfo" class="row">
+	<div class="<%= $footerWidthClass %>">
+		<div id="last-modified"><%= maketext('Page generated at [_1]', $c->timestamp) %></div>
+		<div id="copyright">
+			<%== maketext(
+				'WeBWorK &copy; [_1] | theme: [_2] | ww_version: [_3] | pg_version [_4]',
+				$ce->{WW_COPYRIGHT_YEARS} || '1996-2023',
+				$ce->{defaultTheme}       || 'unknown -- set defaultTheme in localOverides.conf',
+				$ce->{WW_VERSION}         || 'unknown -- set WW_VERSION in VERSION',
+				$ce->{PG_VERSION}         || 'unknown -- set PG_VERSION in ../pg/VERSION'
+			) %>
+		</div>
+		<a href="https://openwebwork.org/"><%= maketext('The WeBWorK Project') %></a>
 	</div>
-	<a href="https://openwebwork.org/"><%= maketext('The WeBWorK Project') %></a>
 </div>

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -19,6 +19,8 @@
 	<%= maketext('Select user(s) and/or set(s) below and click the action button of your choice.') =%>
 </p>
 %
+% stash->{footerWidthClass} = 'col-xl-10';
+%
 <%= form_for current_route, method => 'POST', id => 'instructor-tools-form', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	%

--- a/templates/ContentGenerator/Instructor/Stats/index.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/index.html.ep
@@ -5,6 +5,8 @@
 %
 % my $type = current_route =~ s/instructor_//r;
 %
+% stash->{footerWidthClass} = 'col-lg-10';
+%
 <div class="row">
 	<div class="col-lg-5 col-sm-6 mb-2">
 		<div class="card h-100">

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -67,6 +67,8 @@
 	% last;
 % }
 %
+% stash->{footerWidthClass} = 'col-lg-10';
+%
 <%== $c->post_header_text =%>
 <div id="custom_edit_message" class="row"><div class="col-lg-10"><%= $c->output_custom_edit_message %></div></div>
 <div class="row"><div id="output_summary" class="col-lg-10"><%= $c->output_summary %></div></div>


### PR DESCRIPTION
This sets a default `footerWidthClass` stash value to `col-12` in the ContentGenerator `go` method.  Any module or template can modify that as needed to match its layout.  This is done in
`templates/ContentGenerator/Instructor/Index.html.ep`, `templates/ContentGenerator/Instructor/Stats/index.html.ep`, and `templates/ContentGenerator/Problem.html.ep`.

Note that this can also be done directly in the perl code for any package that derives from the ContentGenerator as well (i.e., in a `.pm` file).  To do so call `$c->stash->{footerWidthClass} = '...'`.

I have left the remaining pages for you to determine, since I am uncertain what you will want on some of them.