### PR TITLE
Suggestions for improvement.

### DIFF
--- a/htdocs/js/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/ProblemSetDetail/problemsetdetail.js
@@ -414,4 +414,10 @@
 		comboBoxSelect.addEventListener('change',
 			() => comboBoxText.value = comboBoxSelect.options[comboBoxSelect.selectedIndex].value);
 	});
+
+	// Set up seed randomization buttons.
+	for (const btn of document.querySelectorAll('.randomize-seed-btn')) {
+		const input = document.getElementById(btn.dataset.seedInput);
+		if (input) btn.addEventListener('click', () => (input.value = Math.floor(Math.random() * 10000)));
+	}
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -950,22 +950,22 @@ sub fieldHTML ($c, $userID, $setID, $problemID, $globalRecord, $userRecord, $fie
 			);
 			if ($field eq 'problem_seed') {
 				# Insert a randomization button
-				$inputType = Mojo::ByteStream->new($c->tag(
+				$inputType = $c->tag(
 					'div',
 					class => 'input-group input-group-sm',
 					style => 'min-width: 7rem',
-					$c->number_field(@field_args, min => 0)->to_string
-						. $c->tag(
+					$c->c(
+						$c->number_field(@field_args, min => 0),
+						$c->tag(
 							'button',
-							type    => 'button',
-							class   => 'btn btn-sm btn-secondary',
-							title   => 'randomize',
-							onclick =>
-							"(function() {document.getElementById('$recordType.$recordID.${field}_id').value = Math.floor(Math.random() * 10000);})();",
+							type  => 'button',
+							class => 'randomize-seed-btn btn btn-sm btn-secondary',
+							title => 'randomize',
+							data  => { seed_input => "$recordType.$recordID.${field}_id" },
 							$c->tag('i', class => 'fa-solid fa-shuffle')
 						)
-				))->html_unescape;
-				warn(ref($inputType));
+					)->join('')
+				);
 			} else {
 				$inputType = $c->text_field(@field_args);
 			}


### PR DESCRIPTION
Inline javascript is bad form.  There is already a javascript file dedicated to the ProblemSetDetail.pm page, so put the javascript there instead.

The return value of the Mojolicious::Plugin::TagHelpers `tag` method is already a Mojo::ByteStream object.  The issue that causes the display to not work is that the contents of the `div` are not, since they are just bare strings concatentated together, and so they are html escaped.  So use a Mojo::Collection that is joined by the empty string.  That also returns a Mojo::ByteStream object, and so it is not html escaped. This is also consistent with how I have done this sort of thing elsewhere in the code.

Also remove what appears to be an errant `warn` statement.