### PR TITLE
Suggested clean up and minor issue fixes.

### DIFF
--- a/htdocs/js/CourseAdmin/restrict_select.js
+++ b/htdocs/js/CourseAdmin/restrict_select.js
@@ -1,31 +1,33 @@
 (() => {
 	const addOnConfSelect = document.getElementById('add_on_conf');
-	const addOnConfOptgroups = [...addOnConfSelect.querySelectorAll('optgroup')];
+	if (!addOnConfSelect) return;
+
+	const addOnConfOptgroups = addOnConfSelect.querySelectorAll('optgroup');
 
 	// Track previously selected options to identify the newly clicked option
 	let previousSelection = [];
 
-	addOnConfSelect.addEventListener('change', (event) => {
-		const currentSelection = Array.from(addOnConfSelect.selectedOptions);
-
+	addOnConfSelect.addEventListener('change', () => {
 		// Find the option the user just clicked/selected
-		const newlySelected = currentSelection.find((option) => !previousSelection.includes(option));
+		const newlySelected = Array.from(addOnConfSelect.selectedOptions).find(
+			(option) => !previousSelection.includes(option)
+		);
 
 		if (newlySelected) {
 			// Find the parent optgroup
 			const parent = newlySelected.closest('optgroup');
 
 			// Loop through all options in the other groups and unselect them as appropriate
-			addOnConfOptgroups.forEach((group) => {
-				Array.from(group.children).forEach((option) => {
+			for (const group of addOnConfOptgroups) {
+				for (const option of group.children) {
 					if (
 						option !== newlySelected &&
 						(parent.dataset.single || (!parent.dataset.single && group.dataset.single))
 					) {
 						option.selected = false;
 					}
-				});
-			});
+				}
+			}
 		}
 
 		// Update tracking variable for the next change event

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -1179,9 +1179,10 @@ sub protectQString {
 
 =item writeCourseConf($fh, $addOnConf)
 
-Writes an essentially empty course.conf file to $fh, a file handle. System
-administrators can use this file to override global settings for a course.
-$addOnConf should be an array reference of config files to tack on at the end.
+Writes the course.conf file to C<$fh>, a file handle. System administrators can
+use this file to override global settings for a course.  If C<$addOnConf> is
+provided, then it should be a reference to an array of config files to be
+included at the end of the course.conf file.
 
 =back
 
@@ -1197,12 +1198,9 @@ sub writeCourseConf {
 
 EOF
 
-	if ($addOnConf ne '') {
+	if (ref $addOnConf eq 'ARRAY') {
 		for my $conf (@$addOnConf) {
-			$content .= <<"EOF";
-
-include('$conf');
-EOF
+			$content .= "\ninclude('$conf');";
 		}
 	}
 

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -221,11 +221,10 @@
 				<%= maketext('course institution (will override "Institution" input above)') =%>
 			</label>
 		</div>
-		% my $addOnConfFolder = $ce->{webworkDirs}{addOnConf};
 		% my @addOnConfFiles;
-		% if (-d $addOnConfFolder) {
-			% @addOnConfFiles = glob "$addOnConfFolder/*.conf";
-			% for (0..$#addOnConfFiles){
+		% if (-d $ce->{webworkDirs}{addOnConf}) {
+			% @addOnConfFiles = glob "$ce->{webworkDirs}{addOnConf}/*.conf";
+			% for (0 .. $#addOnConfFiles){
 				% $addOnConfFiles[$_] =~ s/^.*\/|\.conf$//g;
 			% }
 		% }


### PR DESCRIPTION
The JavaScript needs to not attempt to do anything with the `add_on_conf` select if it is not present in the page, as that causes errors. For instance if the `$webworkDirs{addOnConf}` directory is not present, or is empty.

With modern JavaScript, don't use the array `forEach` method unless it gives a convenient and brief one liner.  Generally prefer a `for of` loop as it is more readable. Another advantage is that `for of` loops work on `HTMLCollection`s and `forEach` does not.  The result of a `querySelectorAll` call or the `children` of an `Element` are `HTMLCollection`s, and so a `for of` loop works directly, while `Array.from` is needed to use `forEach`. This is a minor inefficiency in this case, but that does require constructing an array from the `HTMLCollection`.

I rewrote the `writeCourseConf` POD to clarify its usage some with the new optional parameter.

In the `writeCourseConf` method, it should be checked that the `$addOnConf` variable is an array reference, and not that it is not equal to the empty string. Any numeric value or non empty string is not equal to the empty string and would cause an error if `$addOnConf` is set to any of those.  The check should be that `ref $addOnConf eq 'ARRAY'`. That is the only condition that guarantees an error will not occur and that the value of the variable will work inside the conditional block.

Minor cleanup in the `templates/ContentGenerator/CourseAdmin/add_course_form.html.ep` file. There is no need to copy the value of `$ce->{webworkDirs}{addOnConf}` to a local variable.  Particularly since that can be used directly even in string interpolation.